### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/PoC-rr/2fcffb71-4383-4806-8a6d-7c6e72d57551/9d446d4b-8e4f-4bf7-a689-3996c3c8cde8/_apis/work/boardbadge/28aaf1d9-b283-4682-bbfd-4e414b8a39f2)](https://dev.azure.com/PoC-rr/2fcffb71-4383-4806-8a6d-7c6e72d57551/_boards/board/t/9d446d4b-8e4f-4bf7-a689-3996c3c8cde8/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/PoC-rr/2fcffb71-4383-4806-8a6d-7c6e72d57551/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.